### PR TITLE
feat: improve how to use resource_group in modules

### DIFF
--- a/modules/elastic-ip/outputs.tf
+++ b/modules/elastic-ip/outputs.tf
@@ -32,3 +32,19 @@ output "public_ip" {
   description = "The Elastic IP address."
   value       = aws_eip.this.public_ip
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/elastic-ip/resource-group.tf
+++ b/modules/elastic-ip/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/elastic-ip/variables.tf
+++ b/modules/elastic-ip/variables.tf
@@ -71,23 +71,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/ipam-resource-discovery/outputs.tf
+++ b/modules/ipam-resource-discovery/outputs.tf
@@ -49,3 +49,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/ipam-resource-discovery/resource-group.tf
+++ b/modules/ipam-resource-discovery/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/ipam-resource-discovery/variables.tf
+++ b/modules/ipam-resource-discovery/variables.tf
@@ -39,26 +39,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -78,5 +60,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }

--- a/modules/ipam/outputs.tf
+++ b/modules/ipam/outputs.tf
@@ -92,3 +92,19 @@ output "additional_resource_discoveries" {
     }
   ]
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/ipam/resource-group.tf
+++ b/modules/ipam/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/ipam/variables.tf
+++ b/modules/ipam/variables.tf
@@ -74,23 +74,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/prefix-list/outputs.tf
+++ b/modules/prefix-list/outputs.tf
@@ -49,3 +49,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/prefix-list/resource-group.tf
+++ b/modules/prefix-list/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/prefix-list/variables.tf
+++ b/modules/prefix-list/variables.tf
@@ -60,26 +60,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -99,5 +81,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }


### PR DESCRIPTION
## Summary
Update resource group configuration to use object-based pattern.

## Changes
- Update module version from ~> 0.10.0 to ~> 0.12.0
- Replace individual resource_group_* variables with single object variable  
- Update all references to use var.resource_group.* structure
- Add resource_group output to each module

## Modules Updated
- elastic-ip
- ipam
- ipam-resource-discovery
- prefix-list

## Test Plan
- [ ] Review variable changes
- [ ] Verify resource-group module references are correct  
- [ ] Check outputs are properly formatted